### PR TITLE
Add a pausetimes tool

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,10 @@
  (name eventlog_to_chrome)
  (modules eventlog_to_chrome)
  (public_name ocaml-eventlog-to-chrome)
- (libraries cmdliner bos fpath rresult jsonm eventlog))
+ (libraries bin_common cmdliner bos fpath rresult jsonm eventlog))
+
+(executable
+ (name eventlog_pausetimes)
+ (modules eventlog_pausetimes)
+ (public_name ocaml-eventlog-pausetimes)
+ (libraries bin_common cmdliner bos fpath rresult jsonm interval-map owl-base eventlog))

--- a/bin/eventlog_pausetimes.ml
+++ b/bin/eventlog_pausetimes.ml
@@ -111,9 +111,9 @@ let process_trees state =
     Itv.fold (fun _it v l ->
         if List.length v > 0 then
           let (_, entry, ex, overhead) = List.hd v in ((ex - entry) - overhead) ::l else l
-      ) itv []
+      ) itv acc_latencies
   in
-  latencies::acc_latencies, itv::acc_itvs
+  latencies, itv::acc_itvs
   end state.trees ([], [])
 
 let print_json ~name ~max_latency ~mean_latency distribution =
@@ -139,7 +139,7 @@ let process_latencies name state =
   ] in
   let latencies, _ = process_trees state in
   let sorted_latencies =
-    List.sort Int.compare (List.concat latencies)
+    List.sort Int.compare (latencies)
     |> Array.of_list
     |> Array.map float_of_int
   in

--- a/bin/eventlog_pausetimes.ml
+++ b/bin/eventlog_pausetimes.ml
@@ -1,0 +1,212 @@
+open Rresult.R.Infix
+open Eventlog
+open Bin_common
+
+module Itv = Interval_map.Make(Int)
+module B = Itv.Bound
+module I = Itv.Interval
+
+type entry = {
+  name : phase;
+  overhead : int;
+  ts : int;
+  is_top_level : bool; (* is the event the outermost in the event stack ? *)
+}
+
+type state = {
+    stacks : ((int * int), entry Stack.t) Hashtbl.t;
+    trees : ((int * int), (int * int * entry) list) Hashtbl.t;
+}
+
+exception Mismatched_name of (string * string)
+let raise_mismatched_name en ex =
+  let names = (string_of_phase en, string_of_phase ex) in
+  raise (Mismatched_name names)
+
+let encode_event state ev =
+  if ev.is_backup_thread then (* bt thread, shouldn't count in pausetimes *)
+    state
+  else
+  match ev.payload with
+  | Entry { phase; } -> begin
+     let key = ev.pid, ev.pid in
+     let ts = ev.timestamp in
+     let name = phase in
+     match Hashtbl.find_opt state.stacks key with
+     | Some stack ->
+        let is_top_level = if Stack.length stack = 0 then true else false in
+        Stack.push { ts; name; overhead = 0; is_top_level; } stack; state
+     | None ->
+        let stack = Stack.create () in
+        Stack.push { ts; name; overhead = 0; is_top_level = true; } stack;
+        Hashtbl.add state.stacks key stack;
+        state
+    end
+  | Exit { phase; } -> begin
+     let key = ev.pid, ev.pid in
+     let ts = ev.timestamp in
+     let name = phase in
+     match Hashtbl.find_opt state.stacks key with
+     | None -> state
+     | Some stack ->
+     if Stack.is_empty stack then
+       state (* FIXME(engil): exit event but no entry event? sounds wrong. *)
+     else
+       let entry = Stack.pop stack in
+
+       if entry.name != name then               (* phase mismatch *)
+         raise_mismatched_name entry.name name; (* calculations probably skewed,
+                                                   raise. *)
+       match Hashtbl.find_opt state.trees key with
+       | Some tree ->
+          Hashtbl.replace state.trees key ((entry.ts, ts, entry)::tree);
+          state
+       | None ->
+          Hashtbl.add state.trees key ([(entry.ts, ts, entry)]);
+          state
+    end
+  | Flush { duration; } ->
+     let key = ev.pid, ev.pid in
+     let stack = Hashtbl.find state.stacks key in
+     if Stack.is_empty stack then
+       state (* standalone flush, no overhead to propagate *)
+     else
+       let stack' = Stack.create () in
+       Stack.fold (fun acc e -> { e with overhead = e.overhead + duration; }::acc) [] stack
+       |> List.iter (fun e -> (Stack.push e stack'));
+       Hashtbl.replace state.stacks key stack';
+       state
+  | _ -> state
+
+let finish_marking = phase_of_string "major/finish_marking"
+let finish_sweeping = phase_of_string "major/finish_sweeping"
+let terminate_cond ev = ev.name = finish_marking || ev.name = finish_sweeping
+let top_level_cond ev = if ev.is_top_level then true else false
+let interval b1 b2 = I.create (B.Included b1) (B.Included b2)
+
+let process_trees state =
+  Hashtbl.fold begin fun (_, _) tree (acc_latencies, acc_itvs) ->
+  let itv, terminate_itv =
+    List.fold_left begin fun (itv, terminate_itv) (entry, ex, ev) ->
+      let terminate_itv =
+        if terminate_cond ev then
+          Itv.add (interval entry ex) (ev.name, entry ,ex, ev.overhead) terminate_itv
+        else
+          terminate_itv
+      in
+      let itv =
+        if top_level_cond ev then
+          Itv.add (interval entry ex) (ev.name, entry, ex, ev.overhead) itv
+        else
+          itv
+      in
+      (itv, terminate_itv)
+      end (Itv.empty, Itv.empty) tree
+  in
+  let itv = Itv.fold (fun it _v itv -> Itv.remove_interval it itv) terminate_itv itv in
+  let latencies =
+    Itv.fold (fun _it v l ->
+        if List.length v > 0 then
+          let (_, entry, ex, overhead) = List.hd v in ((ex - entry) - overhead) ::l else l
+      ) itv []
+  in
+  latencies::acc_latencies, itv::acc_itvs
+  end state.trees ([], [])
+
+let print_json ~name ~max_latency ~mean_latency distribution =
+  Printf.printf
+{|{
+  "name": "%s",
+  "mean_latency": %d,
+  "max_latency": %d,
+  "distr_latency": [%s]
+}|}
+    name
+    (int_of_float mean_latency)
+    (int_of_float max_latency)
+    (List.map int_of_float distribution
+     |> List.map string_of_int
+     |> String.concat ",")
+
+
+let process_latencies name state =
+  let percentages = [
+      10.; 20.; 30.; 40.; 50.; 60.;
+      70.; 80.; 90.; 99.; 99.9
+  ] in
+  let latencies, _ = process_trees state in
+  let sorted_latencies =
+    List.sort Int.compare (List.concat latencies)
+    |> Array.of_list
+    |> Array.map float_of_int
+  in
+  let max_latency = sorted_latencies.(Array.length sorted_latencies - 1) in
+  let mean_latency = Owl_base.Stats.mean sorted_latencies in
+  let distribution = List.map (Owl_base.Stats.percentile sorted_latencies) percentages in
+  print_json ~name ~max_latency ~mean_latency distribution
+
+let traverse state file_in =
+  let module P = Eventlog.Parser in
+  match Common.load_file file_in with
+  | Error `Msg err ->
+    Printf.eprintf "[%s] %s\n" (Fpath.to_string file_in) err;
+    state
+  | Ok data ->
+  let decoder = P.decoder () in
+  let total_len = Bigstringaf.length data in
+  P.src decoder data 0 total_len true;
+  let convert state =
+    let rec aux state =
+      match P.decode decoder with
+      | `Ok Event ev ->
+        let state = encode_event state ev in
+        aux state
+      | `Ok _ -> aux state
+      | `Error (`Msg msg) ->
+        Printf.eprintf "[%s] some events were discarded: %s\n" (Fpath.to_string file_in) msg;
+        state
+      | `End -> state
+      | `Await -> state
+    in
+    let state = aux state in
+    state
+  in
+  convert state
+
+let main src_in name =
+  let aux () =
+    let stacks = Hashtbl.create 128 in
+    let trees = Hashtbl.create 128 in
+    let state = { stacks; trees; } in
+    Common.load src_in >>= fun tracedir ->
+    let state = List.fold_left traverse state tracedir in
+    Ok state
+  in
+  match aux () with
+  | Error err -> Error err
+  | Ok state -> process_latencies name state; Ok ()
+
+
+module Args = struct
+
+  open Cmdliner
+
+  let name =
+    let doc = "Name for the compiler switch" in
+    Arg.(required & pos ~rev:true 0 (some string) None & info [] ~docv:"NAME" ~doc)
+  let srcs =
+     let doc = "Source file(s) to copy. You can also pass a directory as an argument and it will process all files within this directory." in
+     Arg.(non_empty & pos_left ~rev:true 0 file [] & info [] ~docv:"SOURCE" ~doc)
+  let info =
+    let doc = "" in
+    let man = [
+      `S Manpage.s_bugs;
+    ]
+    in
+    Term.info "ocaml-eventlog-pausetimes" ~version:"%%VERSION%%" ~doc ~exits:Term.default_exits ~man
+
+end
+
+let () =
+  let open Cmdliner in
+  Term.exit @@ Term.eval Term.(const main $ Args.srcs $ Args.name, Args.info)

--- a/bin_common/common.ml
+++ b/bin_common/common.ml
@@ -1,0 +1,25 @@
+open Rresult.R.Infix
+
+let load_as_dir path =
+  Fpath.of_string path >>= fun path ->
+  match Bos.OS.File.exists path with
+  | Ok true -> Ok [ path ]
+  | Ok false -> Bos.OS.Dir.contents path
+  | Error err -> Error err
+
+let load_file path =
+  let open Rresult.R.Infix in
+  Bos.OS.File.read path
+  >>= fun content ->
+  Ok (Bigstringaf.of_string ~off:0 ~len:(String.length content) content)
+
+let load paths =
+  let rec aux l acc =
+    match l with
+    | [] -> Ok acc
+    | path::xs ->
+      match load_as_dir path with
+      | Ok res -> aux xs (res::acc)
+      | Error err -> Error err
+  in
+  aux paths [] |> Result.map List.flatten

--- a/bin_common/dune
+++ b/bin_common/dune
@@ -1,0 +1,3 @@
+(library
+ (name bin_common)
+ (libraries fpath bos rresult bigstringaf))

--- a/eventlog-tools.opam
+++ b/eventlog-tools.opam
@@ -27,9 +27,6 @@ depends: [
   "ocaml"      {>= "4.09.0"}
   "dune"       {build}
   "alcotest"   {test}
-  "base-bytes"
-  "base-bigarray"
-  "base-unix"
   "bigstringaf"
   "angstrom"
   "rresult"

--- a/eventlog-tools.opam
+++ b/eventlog-tools.opam
@@ -39,4 +39,5 @@ depends: [
   "fpath"
   "bos"
   "owl-base"
+  "interval-map"
 ]

--- a/lib/eventlog.mli
+++ b/lib/eventlog.mli
@@ -30,6 +30,7 @@ type packet =
 val string_of_gc_counter : counter_kind -> string
 val string_of_alloc_bucket : bucket -> string
 val string_of_phase : phase -> string
+val phase_of_string : string -> phase
 
 module Parser : sig
 

--- a/lib/eventlog.mli
+++ b/lib/eventlog.mli
@@ -44,6 +44,4 @@ val decode : decoder -> [> `Await
 
 val src : decoder -> Bigstringaf.t -> int -> int -> bool -> unit
 
-val parse_event : endianness -> packet Angstrom.t
-
 end

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -58,12 +58,12 @@ let parse_event e trace_version =
   let parse_event_header =
     any_int64 >>= fun timestamp ->
     (match trace_version with
-    | `Version 0x1337 ->
+    | `Version 0x654321 (* multicore *) ->
       any_int32 >>= fun event_type ->
       any_int32 >>= fun pid ->
       any_int8 >>= fun is_bt ->
       return (event_type, pid, is_bt != 0)
-    | `Version 0x1 ->
+    | `Version 0x1 (* current trunk *) ->
       any_int32 >>= fun pid ->
       any_int32 >>= fun event_type ->
       return (event_type, pid, false)
@@ -88,7 +88,7 @@ let parse_magic : endianness t = magic_be <|> magic_le
 let parse_header =
   parse_magic >>= fun endianness ->
   caml_trace_version endianness >>= fun ocaml_trace_version ->
-  if ocaml_trace_version != 0x1 && ocaml_trace_version != 0x1337 then
+  if ocaml_trace_version != 0x1 && ocaml_trace_version != 0x654321 then
     fail (Printf.sprintf "invalid ocaml_trace_version: %d" ocaml_trace_version)
   else
     stream_id endianness >>= fun () ->

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -158,4 +158,4 @@ let src d src src_off src_len complete =
   d.buffer <- dst;
   d.off <- 0;
   d.len <- dst_len;
-  d.complete <- if complete then Unbuffered.Complete else Unbuffered.Incomplete;
+  d.complete <- if complete then Unbuffered.Complete else Unbuffered.Incomplete

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -58,7 +58,7 @@ let parse_event e trace_version =
   let parse_event_header =
     any_int64 >>= fun timestamp ->
     (match trace_version with
-    | `Version 0x654321 (* multicore *) ->
+    | `Version 0x100 (* multicore *) ->
       any_int32 >>= fun event_type ->
       any_int32 >>= fun pid ->
       any_int8 >>= fun is_bt ->
@@ -88,7 +88,7 @@ let parse_magic : endianness t = magic_be <|> magic_le
 let parse_header =
   parse_magic >>= fun endianness ->
   caml_trace_version endianness >>= fun ocaml_trace_version ->
-  if ocaml_trace_version != 0x1 && ocaml_trace_version != 0x654321 then
+  if ocaml_trace_version != 0x1 && ocaml_trace_version != 0x100 then
     fail (Printf.sprintf "invalid ocaml_trace_version: %d" ocaml_trace_version)
   else
     stream_id endianness >>= fun () ->

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -25,68 +25,62 @@ let (>>?) v f =
   | Error `Msg msg -> fail msg
 
 
-let parse_event e =
-  let int32 = match e with Be -> BE.int32 | Le -> LE.int32 in
+let parse_event e trace_version =
   let any_int16 = match e with Be -> BE.any_int16 | Le -> LE.any_int16 in
   let any_int32 = match e with Be -> BE.any_int32 | Le -> LE.any_int32 in
   let any_int64 = match e with Be -> BE.any_int64 | Le -> LE.any_int64 in
-  let event_context =
-    any_int32 >>= fun pid ->
-    any_int8 >>= fun is_bt ->
-    return (pid, is_bt)
-  in
-  let parse_event_type i = int32 i >>= fun () -> event_context  <|> (fail (Printf.sprintf "smh 0x%lx" i)) in
   let entry_event =
-    parse_event_type 0x0l
-    >>= fun ctx ->
     any_int16 >>= fun i ->
     phase_of_int i >>? fun phase ->
-    return (ctx, (Entry { phase; }))
+    return (Entry { phase; })
   in
   let exit_event =
-    parse_event_type 0x1l
-    >>= fun ctx ->
     any_int16 >>= fun i ->
     phase_of_int i >>? fun phase ->
-    return (ctx, (Exit { phase; }))
+    return (Exit { phase; })
   in
   let counter_event =
-    parse_event_type 0x2l
-    >>= fun ctx ->
     any_int64 >>= fun count ->
     any_int16 >>= fun i ->
     gc_counter_of_int i >>? fun kind ->
-    return (ctx, (Counter { count = Int64.to_int count; kind; }))
+    return (Counter { count = Int64.to_int count; kind; })
   in
   let alloc_event =
-    parse_event_type 0x3l
-    >>= fun ctx ->
     any_int64 >>= fun count ->
     any_int8 >>= fun i ->
     alloc_bucket_of_int i >>? fun bucket ->
-    return (ctx, (Alloc { count = Int64.to_int count; bucket; }))
+    return (Alloc { count = Int64.to_int count; bucket; })
   in
   let flush_event =
-    parse_event_type 0x4l
-    >>= fun ctx ->
     any_int64 >>= fun duration ->
-    return (ctx, (Flush { duration = Int64.to_int duration; }))
+    return (Flush { duration = Int64.to_int duration; })
   in
-  let event_header =
+  let parse_event_header =
     any_int64 >>= fun timestamp ->
-    return (timestamp)
+    (match trace_version with
+    | `Version 0x1337 ->
+      any_int32 >>= fun event_type ->
+      any_int32 >>= fun pid ->
+      any_int8 >>= fun is_bt ->
+      return (event_type, pid, is_bt != 0)
+    | `Version 0x1 ->
+      any_int32 >>= fun pid ->
+      any_int32 >>= fun event_type ->
+      return (event_type, pid, false)
+    | _ -> assert false)
+    >>= fun (event_type, pid, is_bt) ->
+    return (timestamp, event_type, pid, is_bt)
   in
-  let event_parser =
-    entry_event
-    <|> exit_event
-    <|> alloc_event
-    <|> counter_event
-    <|> flush_event
-  in
-  event_header >>= fun timestamp ->
-  event_parser >>= fun (context, payload) ->
-  let is_backup_thread = (snd context) != 0 in
-  Event {payload; is_backup_thread; timestamp = Int64.to_int timestamp; pid = Int32.to_int (fst context); }
+  parse_event_header >>= fun (timestamp, event_type, pid, is_bt) ->
+  (match event_type with
+  | 0x0l -> entry_event
+  | 0x1l -> exit_event
+  | 0x2l -> counter_event
+  | 0x3l -> alloc_event
+  | 0x4l -> flush_event
+  | i -> fail (Printf.sprintf "invalid event_type 0x%lxd" i))
+  >>= fun (payload) ->
+  Event {payload; is_backup_thread = is_bt; timestamp = Int64.to_int timestamp; pid = Int32.to_int pid; }
   |> return
 
 let parse_magic : endianness t = magic_be <|> magic_le
@@ -107,6 +101,7 @@ type decoder = {
   mutable state : packet Unbuffered.state;
   mutable complete : Unbuffered.more;
   mutable parser : packet t;
+  mutable version : [ `Unconfigured | `Version of int ];
 }
 
 let rec decode d =
@@ -115,8 +110,8 @@ let rec decode d =
     d.off <- d.off + i;
     begin
       match v with
-      | Header { endianness; _ } ->
-        d.parser <- parse_event endianness;
+      | Header { endianness; ocaml_trace_version; _ } ->
+        d.parser <- parse_event endianness (`Version ocaml_trace_version);
       | _ -> ()
     end;
     d.state <- Unbuffered.parse d.parser;
@@ -145,9 +140,10 @@ let decoder () =
   let len = 0x0 in
   let off = 0x0 in
   let parser = parse_header in
+  let version = `Unconfigured in
   let state = Unbuffered.parse parse_header in
   let complete = Unbuffered.Incomplete in
-  { buffer; len; off; state; complete; parser; }
+  { buffer; len; off; state; complete; parser; version; }
 
 let src d src src_off src_len complete =
   let uncommited = d.len - d.off in

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -88,7 +88,7 @@ let parse_magic : endianness t = magic_be <|> magic_le
 let parse_header =
   parse_magic >>= fun endianness ->
   caml_trace_version endianness >>= fun ocaml_trace_version ->
-  if ocaml_trace_version != 0x1 then
+  if ocaml_trace_version != 0x1 && ocaml_trace_version != 0x1337 then
     fail (Printf.sprintf "invalid ocaml_trace_version: %d" ocaml_trace_version)
   else
     stream_id endianness >>= fun () ->

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -33,6 +33,13 @@ let string_of_phase i = Consts.phase.(i)
 let string_of_gc_counter i = Consts.gc_counter.(i)
 let string_of_alloc_bucket i = Consts.alloc_bucket.(i)
 
+let phase_of_string s : phase =
+  let rec aux i =
+    if i > (Array.length Consts.phase) - 1 then raise Not_found;
+    if String.equal Consts.phase.(i) s then i else aux (i + 1)
+  in
+  aux 0
+
 let phase_of_int i =
   if i < Array.length Consts.phase then
     R.return i

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -34,3 +34,5 @@ val string_of_phase : phase -> string
 val gc_counter_of_int : int -> (counter_kind, [> Rresult.R.msg ]) result
 val alloc_bucket_of_int : int -> (bucket, [> Rresult.R.msg ]) result
 val phase_of_int : int -> (phase, [> Rresult.R.msg ]) result
+
+val phase_of_string : string -> phase


### PR DESCRIPTION
This commit introduce `eventlog_pausetimes`.
This tool is based on the existing script within [sandmark](https://github.com/ocaml-bench/sandmark/blob/master/pausetimes/process_eventlog.py).
It is a straightforward re-implementation of it:
- It takes for input one, several, of a directory of eventlog files (to align with Multicore's current CTF emitter emitting one file per domain.)
- It computes the mean, max pause times, as well a the distribution up to the `99.9th` percentiles.

Example run:
```
●●● ocaml-eventlog-pausetimes /home/engil/dev/ocaml-multicore/trace3/caml-426094-* name
{
  "name": "name",
  "mean_latency": 718617,
  "max_latency": 33839379,
  "distr_latency": [191,250,707,16886,55829,105386,249272,552640,1325621,13312993,26227671]
}⏎     
```

A review of the said script would be appreciated.

Several implementation details to keep in mind:
- The flush events (flushing overhead) time is removed from the current event scope. I think this may be enough to remove overhead but let me know if I missed something.
- Error handling is a bit wonky. Some non-dramatic errors outputs to stderr (but do not fail the program), some others do hard fail (`phase` mismatch which implies a potential skew in calculation). Some suggestions on how we want error handling to behave would be appreciated.

See as well ocaml-bench/sandmark#218