### PR TITLE
update consts.ml to work with OCaml 4.13

### DIFF
--- a/lib/consts.ml
+++ b/lib/consts.ml
@@ -40,6 +40,7 @@ let gc_counter = [|
   "force_minor/make_vect";
   "force_minor/set_minor_heap_size";
   "force_minor/weak";
+  "force_minor/memprof";
   "major/mark/slice/remain";
   "major/mark/slice/fields";
   "major/mark/slice/pointers";


### PR DESCRIPTION
This will update eventlog-tools to work with OCaml 4.13.1 (the latest release).

However, OCaml trunk has already diverged from this (big time!) so we can't get a version of eventlog-tools that works for both (or for older versions of OCaml).

I see three solutions to this problem:
1. Release a new version of eventlog-tools for each change in OCaml (including trunk changes, obviously).
2. Upstream eventlog-tools and let the OCaml developers update it with each release.
3. Manage caml_trace_version seriously (increase it with every change) and make eventlog-tools understand every version of the format.
